### PR TITLE
fix: import from apollo core to remove react dependency

### DIFF
--- a/src/proxyCacheLink.ts
+++ b/src/proxyCacheLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, FetchResult, Observable } from '@apollo/client'
+import { ApolloLink, FetchResult, Observable } from '@apollo/client/core'
 import { hasDirectives } from 'apollo-utilities'
 import type { Subscription } from 'zen-observable-ts'
 import {


### PR DESCRIPTION
In `src/proxyCacheLink.ts` Apollo is imported from `@apollo/client`, which requires to have react installed in the project. Otherwise we get an error like this:
```
Error: Cannot find module 'react'
Require stack:
- /Users/Roman/Work/repos/gql-cache-test/node_modules/apollo-proxy-cache/node_modules/@apollo/client/react/context/context.cjs
- /Users/Roman/Work/repos/gql-cache-test/node_modules/apollo-proxy-cache/node_modules/@apollo/client/react/react.cjs
- /Users/Roman/Work/repos/gql-cache-test/node_modules/apollo-proxy-cache/node_modules/@apollo/client/main.cjs
- /Users/Roman/Work/repos/gql-cache-test/node_modules/apollo-proxy-cache/dist/node/proxyCacheLink.js
- /Users/Roman/Work/repos/gql-cache-test/node_modules/apollo-proxy-cache/dist/node/index.js
```

This PR fixes the problem by changing the import to `@apollo/client/core` not including the react hooks and classes.